### PR TITLE
Update controller_pack_plugins.json

### DIFF
--- a/.github/controller_pack_plugins.json
+++ b/.github/controller_pack_plugins.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "EuroscopeRPC",
-      "current": "1.0.0",
+      "current": "1.0.2",
       "github": "AlexisBalzano/EuroscopeRPC",
       "include_prereleases": false
     },


### PR DESCRIPTION
Bumps up the EuroscopeRPC plugin version to avoid the workflow notifying us again 