### PR TITLE
feat(pack-sync): support combined LFXXN package for LFFF and LFEE

### DIFF
--- a/installer/core/src/pack_sync/airac.rs
+++ b/installer/core/src/pack_sync/airac.rs
@@ -17,16 +17,60 @@ use std::sync::OnceLock;
 pub fn parse_gng_sector_filename(name: &str) -> Option<(FirCode, Option<String>)> {
     // Look for a leading FIR code followed by a delimiter we recognise.
     let fir = leading_fir_code(name)?;
+    Some((fir, parse_airac_cycle(name)))
+}
 
-    // FIR found. Try to extract an AIRAC cycle. The cycle is the first
-    // 6-digit numeric group found between dashes.
-    let cycle = SIX_DIGIT_GROUP
+/// The GNG "combined" sector code for the northern France pack. Its single
+/// sector file serves both the Paris (LFFF) and Reims (LFEE) FIRs.
+pub const LFXXN_CODE: &str = "LFXXN";
+
+/// Parse a GNG sector/profile filename into the *set* of FIRs it covers plus the
+/// AIRAC cycle. Unlike [`parse_gng_sector_filename`], a combined code such as
+/// `LFXXN` resolves to several FIRs (e.g. `LFXXN-Paris-Reims_…` → LFFF + LFEE).
+/// A regular `<FIR>-…` filename resolves to that single FIR.
+///
+/// Examples:
+///   "LFXXN-Paris-Reims_20260605153747-260501-0001.sct" → ([LFFF, LFEE], "2605")
+///   "LFBB-Bordeaux-260301-0003.sct"                    → ([LFBB], "2603")
+pub fn parse_gng_sector_target(name: &str) -> Option<(Vec<FirCode>, Option<String>)> {
+    // A combined code (e.g. LFXXN) takes precedence; no FIR code is a prefix of
+    // it, so the order relative to the single-FIR check is not load-bearing.
+    let firs = if let Some(combined) = leading_combined_code(name) {
+        combined.to_vec()
+    } else {
+        vec![leading_fir_code(name)?]
+    };
+    Some((firs, parse_airac_cycle(name)))
+}
+
+/// Extract the AIRAC cycle: the first 6-digit numeric group found between
+/// dashes, of which the first 4 digits (YYMM) are the cycle. Returns `None` when
+/// no such group is present (e.g. a bare `LFBB.sct`). The `_`-prefixed 14-digit
+/// creation timestamp in newer GNG names is not delimited by dashes, so it is
+/// never mistaken for the cycle.
+fn parse_airac_cycle(name: &str) -> Option<String> {
+    SIX_DIGIT_GROUP
         .get_or_init(|| Regex::new(r"-(\d{6})-").expect("regex"))
         .captures(name)
         .and_then(|c| c.get(1))
-        .map(|m| cycle_from_six_digits(m.as_str()));
+        .map(|m| cycle_from_six_digits(m.as_str()))
+}
 
-    Some((fir, cycle))
+/// If `name` starts with a known combined code followed by a separator, the FIRs
+/// it covers. Mirrors [`leading_fir_code`]'s prefix+separator matching so that
+/// e.g. `LFXXNX` does not match.
+fn leading_combined_code(name: &str) -> Option<&'static [FirCode]> {
+    const COMBINED: &[(&str, &[FirCode])] =
+        &[(LFXXN_CODE, &[FirCode::LFFF, FirCode::LFEE])];
+    let upper = name.to_ascii_uppercase();
+    for (code, firs) in COMBINED {
+        if let Some(rest) = upper.strip_prefix(code) {
+            if rest.is_empty() || matches!(rest.chars().next(), Some('-' | '_' | ' ' | '.')) {
+                return Some(firs);
+            }
+        }
+    }
+    None
 }
 
 static SIX_DIGIT_GROUP: OnceLock<Regex> = OnceLock::new();
@@ -105,5 +149,45 @@ mod tests {
         assert!(parse_gng_sector_filename("LFXX-Base-260301-0003.sct").is_none());
         // LFXY is gibberish — not a known FIR.
         assert!(parse_gng_sector_filename("LFXY-Random.sct").is_none());
+    }
+
+    #[test]
+    fn combined_lfxxn_resolves_to_lfff_and_lfee() {
+        // The real GNG combined name embeds an `_`-prefixed 14-digit creation
+        // timestamp before the AIRAC group; the cycle must be the `-260501-`
+        // group (→ 2605), not any 6 digits of the timestamp.
+        let (firs, cycle) =
+            parse_gng_sector_target("LFXXN-Paris-Reims_20260605153747-260501-0001.sct").unwrap();
+        assert_eq!(firs, vec![FirCode::LFFF, FirCode::LFEE]);
+        assert_eq!(cycle.as_deref(), Some("2605"));
+    }
+
+    #[test]
+    fn combined_lfxxn_ese_variant() {
+        let (firs, cycle) =
+            parse_gng_sector_target("LFXXN-Paris-Reims_20260605153747-260501-0001.ese").unwrap();
+        assert_eq!(firs, vec![FirCode::LFFF, FirCode::LFEE]);
+        assert_eq!(cycle.as_deref(), Some("2605"));
+    }
+
+    #[test]
+    fn combined_lfxxn_is_not_a_single_fir() {
+        // The legacy single-FIR parser must not claim LFXXN as a FIR.
+        assert!(parse_gng_sector_filename("LFXXN-Paris-Reims_20260605153747-260501-0001.sct")
+            .is_none());
+    }
+
+    #[test]
+    fn sector_target_falls_back_to_single_fir() {
+        let (firs, cycle) =
+            parse_gng_sector_target("LFBB-Bordeaux-260301-0003.sct").unwrap();
+        assert_eq!(firs, vec![FirCode::LFBB]);
+        assert_eq!(cycle.as_deref(), Some("2603"));
+    }
+
+    #[test]
+    fn combined_code_requires_separator() {
+        // A longer code that merely starts with LFXXN must not match.
+        assert!(parse_gng_sector_target("LFXXNX-Random.sct").is_none());
     }
 }

--- a/installer/core/src/pack_sync/integration_test.rs
+++ b/installer/core/src/pack_sync/integration_test.rs
@@ -79,6 +79,21 @@ fn build_fake_gng_package() -> (TempDir, PathBuf) {
     (tmp, root)
 }
 
+/// The GNG combined "North" package: a single sector file (plus `.ese`/`.rwy`)
+/// named with the `LFXXN` combined code that must fan out to BOTH LFFF and LFEE.
+/// Uses the real GNG filename shape, with an `_`-prefixed creation timestamp
+/// before the `-260501-` AIRAC group.
+fn build_fake_lfxxn_package() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    write_file(&root, "LFXXN-Paris-Reims_20260605153747-260501-0001.sct", "north sct\n");
+    write_file(&root, "LFXXN-Paris-Reims_20260605153747-260501-0001.ese", "north ese\n");
+    write_file(&root, "LFXXN-Paris-Reims_20260605153747-260501-0001.rwy", "north rwy\n");
+
+    (tmp, root)
+}
+
 fn build_existing_install() -> TempDir {
     let tmp = TempDir::new().unwrap();
     let install_root = tmp.path();
@@ -326,4 +341,118 @@ fn github_only_refresh_updates_installed_areas_without_packages() {
     // Areas that were NOT installed stay absent (LFEE has no folder; LFFM secret).
     assert!(!files.iter().any(|f| f.starts_with("LFEE/")), "got: {files:#?}");
     assert!(!files.iter().any(|f| f.starts_with("LFFM/")), "got: {files:#?}");
+}
+
+#[test]
+fn lfxxn_package_fans_out_to_lfff_and_lfee() {
+    let (_gh_tmp, github_root) = build_fake_github_repo();
+    let (_pkg_tmp, pkg_root) = build_fake_lfxxn_package();
+    let install_tmp = TempDir::new().unwrap();
+    let install_root = install_tmp.path();
+
+    let gng_roots = vec![pkg_root.clone()];
+    let plan = plan(PlanInputs {
+        github_root: Some(&github_root),
+        gng_roots: &gng_roots,
+        install_root,
+        github_short_sha: Some("abcdef1".into()),
+        area_source: AreaSource::Packages,
+    })
+    .unwrap();
+    let summary = apply(install_root, &plan).unwrap();
+    let files = list_files(install_root);
+
+    // The single combined source is written as BOTH LFFF and LFEE sectors.
+    for (fir, ext, content) in [
+        ("LFFF", "sct", "north sct"),
+        ("LFEE", "sct", "north sct"),
+        ("LFFF", "ese", "north ese"),
+        ("LFEE", "ese", "north ese"),
+        ("LFFF", "rwy", "north rwy"),
+        ("LFEE", "rwy", "north rwy"),
+    ] {
+        let body =
+            fs::read_to_string(install_root.join(format!("LFXX/Sectors/{fir}.{ext}"))).unwrap();
+        assert_eq!(body.trim(), content, "LFXX/Sectors/{fir}.{ext}");
+    }
+
+    // AIRAC parsed past the `_`-prefixed timestamp → 2605.
+    let marker = fs::read_to_string(install_root.join("LFXX/Sectors/current_airac.txt")).unwrap();
+    assert_eq!(marker.trim(), "2605");
+    assert_eq!(summary.airac_cycle.as_deref(), Some("2605"));
+
+    // GitHub overlay folders for BOTH covered FIRs are installed...
+    assert!(files.contains(&"LFFF/ASR/Paris.asr".to_string()));
+    assert!(files.contains(&"LFEE/ASR/Reims.asr".to_string()));
+    // ...and no unrelated FIR overlay is (LFBB has no package here; LFFM secret).
+    assert!(!files.iter().any(|f| f.starts_with("LFBB/")), "got: {files:#?}");
+    assert!(!files.iter().any(|f| f.starts_with("LFFM/")), "got: {files:#?}");
+}
+
+#[test]
+fn lfxxn_backs_up_existing_lfff_and_lfee_sectors() {
+    let (_gh_tmp, github_root) = build_fake_github_repo();
+    let (_pkg_tmp, pkg_root) = build_fake_lfxxn_package();
+    let install_tmp = TempDir::new().unwrap();
+    let install_root = install_tmp.path();
+
+    // Pre-existing LFFF/LFEE sectors at the previous AIRAC cycle.
+    write_file(install_root, "LFXX/Sectors/LFFF.sct", "old paris\n");
+    write_file(install_root, "LFXX/Sectors/LFEE.sct", "old reims\n");
+    write_file(install_root, "LFXX/Sectors/current_airac.txt", "2602\n");
+
+    let gng_roots = vec![pkg_root.clone()];
+    apply(
+        install_root,
+        &plan(PlanInputs {
+            github_root: Some(&github_root),
+            gng_roots: &gng_roots,
+            install_root,
+            github_short_sha: Some("abcdef1".into()),
+            area_source: AreaSource::Packages,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    // Both prior sectors were backed up under the previous AIRAC before overwrite.
+    let lfff_bak =
+        fs::read_to_string(install_root.join("LFXX/Sectors/Backup/LFFF-2602.sct")).unwrap();
+    assert_eq!(lfff_bak.trim(), "old paris");
+    let lfee_bak =
+        fs::read_to_string(install_root.join("LFXX/Sectors/Backup/LFEE-2602.sct")).unwrap();
+    assert_eq!(lfee_bak.trim(), "old reims");
+    // ...and the new combined content is in place.
+    let lfff = fs::read_to_string(install_root.join("LFXX/Sectors/LFFF.sct")).unwrap();
+    assert_eq!(lfff.trim(), "north sct");
+}
+
+#[test]
+fn lfxxn_second_run_is_a_no_op() {
+    let (_gh_tmp, github_root) = build_fake_github_repo();
+    let (_pkg_tmp, pkg_root) = build_fake_lfxxn_package();
+    let install_tmp = TempDir::new().unwrap();
+    let install_root = install_tmp.path();
+    // Settings already match GitHub so the settings-backup step stabilises after
+    // the first apply (mirrors `second_run_is_a_no_op`).
+    write_file(install_root, "LFXX/Settings/Symbology.txt", "sym\n");
+    let gng_roots = vec![pkg_root.clone()];
+
+    let inputs = || PlanInputs {
+        github_root: Some(&github_root),
+        gng_roots: &gng_roots,
+        install_root,
+        github_short_sha: Some("abcdef1".into()),
+        area_source: AreaSource::Packages,
+    };
+
+    apply(install_root, &plan(inputs()).unwrap()).unwrap();
+    let summary = apply(install_root, &plan(inputs()).unwrap()).unwrap();
+    assert_eq!(summary.files_written, 0, "second LFXXN run should be a no-op");
+    // No spurious backups were created for the unchanged combined targets.
+    let files = list_files(install_root);
+    assert!(
+        !files.iter().any(|f| f.starts_with("LFXX/Sectors/Backup/")),
+        "no backups expected on a no-op run; got: {files:#?}"
+    );
 }

--- a/installer/core/src/pack_sync/plan.rs
+++ b/installer/core/src/pack_sync/plan.rs
@@ -1,4 +1,4 @@
-use super::airac::parse_gng_sector_filename;
+use super::airac::{parse_gng_sector_target, LFXXN_CODE};
 use super::ownership::{gng_owned_set, is_gng_owned};
 use super::{COPYRIGHT_FILE, CURRENT_AIRAC_FILE, SECTORS_SUBPATH, SECTOR_BACKUP_DIRNAME};
 use crate::fir::FirCode;
@@ -126,6 +126,13 @@ fn detect_installed_codes(gng_roots: &[PathBuf]) -> (BTreeSet<FirCode>, bool) {
                 if matches_code(&upper, fir.as_str()) {
                     firs.insert(fir);
                 }
+            }
+            // The combined LFXXN package covers both LFFF and LFEE. LFXXN is not
+            // a FIR (and no FIR code is a prefix of it), so it is matched
+            // explicitly and expands to both covered FIRs.
+            if matches_code(&upper, LFXXN_CODE) {
+                firs.insert(FirCode::LFFF);
+                firs.insert(FirCode::LFEE);
             }
             if matches_code(&upper, LFFM_CODE) {
                 lffm = true;
@@ -395,20 +402,24 @@ fn plan_gng_overlay(
             .extension()
             .map(|e| e.to_string_lossy().to_ascii_lowercase());
 
-        // Sector files: rename to <FIR>.<ext>, place in LFXX/Sectors/.
+        // Sector files: rename to <FIR>.<ext>, place in LFXX/Sectors/. A combined
+        // code (e.g. LFXXN) fans the single source file out to one renamed sector
+        // per covered FIR.
         if let Some(ext) = ext.as_deref().and_then(SectorExt::from_str) {
-            if let Some((fir, cycle)) = parse_gng_sector_filename(&name) {
+            if let Some((firs, cycle)) = parse_gng_sector_target(&name) {
                 if let Some(c) = cycle.clone() {
                     plan.detected_airac = Some(c);
                 }
-                let dst = sectors_dir.join(format!("{}.{}", fir.as_str(), ext.as_str()));
-                sector_writes.push(FileOp::WriteSector {
-                    src: path.to_path_buf(),
-                    dst,
-                    fir,
-                    ext,
-                });
-                sector_targets.insert((fir, ext));
+                for fir in firs {
+                    let dst = sectors_dir.join(format!("{}.{}", fir.as_str(), ext.as_str()));
+                    sector_writes.push(FileOp::WriteSector {
+                        src: path.to_path_buf(),
+                        dst,
+                        fir,
+                        ext,
+                    });
+                    sector_targets.insert((fir, ext));
+                }
                 continue;
             }
             // Not a FIR sector filename — skip (e.g. sub-sector includes). This
@@ -418,14 +429,17 @@ fn plan_gng_overlay(
             continue;
         }
 
-        // `.rwy` files: keep, paired with the sector dir as <FIR>.rwy.
+        // `.rwy` files: keep, paired with the sector dir as <FIR>.rwy. A combined
+        // code fans the single source out to one <FIR>.rwy per covered FIR.
         if ext.as_deref() == Some("rwy") {
-            if let Some((fir, _)) = parse_gng_sector_filename(&name) {
-                let dst = sectors_dir.join(format!("{}.rwy", fir.as_str()));
-                plan.ops.push(FileOp::Copy {
-                    src: path.to_path_buf(),
-                    dst,
-                });
+            if let Some((firs, _)) = parse_gng_sector_target(&name) {
+                for fir in firs {
+                    let dst = sectors_dir.join(format!("{}.rwy", fir.as_str()));
+                    plan.ops.push(FileOp::Copy {
+                        src: path.to_path_buf(),
+                        dst,
+                    });
+                }
             }
             continue;
         }

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "French vACC Controller Pack Installer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "fr.vacc.controller-pack-installer",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
The GNG LFXXN North package ships one sector file serving both the Paris (LFFF) and Reims (LFEE) FIRs. Recognise LFXXN as a combined code: detecting it installs both FIRs' GitHub overlays, and the LFXXN .sct/.ese/.rwy files fan out to LFFF.* and LFEE.* in LFXX/Sectors, with the usual backup and no-op handling per destination.