### PR TITLE
installer: install the LFFM sector files

### DIFF
--- a/installer/Cargo.lock
+++ b/installer/Cargo.lock
@@ -413,7 +413,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "controller-pack-core"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "controller-pack-installer"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "controller-pack-core",

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["core", "src-tauri"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.77"
 

--- a/installer/core/src/fir.rs
+++ b/installer/core/src/fir.rs
@@ -51,3 +51,63 @@ impl std::fmt::Display for FirCode {
         f.write_str(self.as_str())
     }
 }
+
+/// The military / legacy area. Not an ICAO FIR, but it owns an area folder and a
+/// sector file (`LFXX/Sectors/LFFM.sct`) exactly like a FIR does.
+pub const LFFM_CODE: &str = "LFFM";
+
+/// An installable area: one of the French FIRs, or `LFFM`.
+///
+/// `LFFM` is deliberately kept out of [`FirCode`] — it is not a FIR and the
+/// GitHub overlay gates it separately (it is only installed when its package is
+/// selected). It is, however, laid out like one: its own folder, its own `.prf`
+/// reading `\ICAO\…` / `\NavData\…` relative to that folder, and its own sector
+/// file. Anything keyed on "which area does this file belong to" therefore uses
+/// this type rather than `FirCode`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AreaCode {
+    Fir(FirCode),
+    Lffm,
+}
+
+impl AreaCode {
+    /// Every area, in a stable order.
+    pub const ALL: [AreaCode; 6] = [
+        AreaCode::Fir(FirCode::LFBB),
+        AreaCode::Fir(FirCode::LFEE),
+        AreaCode::Fir(FirCode::LFFF),
+        AreaCode::Fir(FirCode::LFMM),
+        AreaCode::Fir(FirCode::LFRR),
+        AreaCode::Lffm,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AreaCode::Fir(fir) => fir.as_str(),
+            AreaCode::Lffm => LFFM_CODE,
+        }
+    }
+}
+
+impl From<FirCode> for AreaCode {
+    fn from(fir: FirCode) -> Self {
+        AreaCode::Fir(fir)
+    }
+}
+
+impl FromStr for AreaCode {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case(LFFM_CODE) {
+            return Ok(AreaCode::Lffm);
+        }
+        s.parse::<FirCode>().map(AreaCode::Fir)
+    }
+}
+
+impl std::fmt::Display for AreaCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/installer/core/src/lib.rs
+++ b/installer/core/src/lib.rs
@@ -3,4 +3,4 @@ pub mod pack_sync;
 pub mod profile_configurator;
 pub mod profile_types;
 
-pub use fir::FirCode;
+pub use fir::{AreaCode, FirCode};

--- a/installer/core/src/pack_sync/airac.rs
+++ b/installer/core/src/pack_sync/airac.rs
@@ -1,4 +1,4 @@
-use crate::fir::FirCode;
+use crate::fir::{AreaCode, FirCode, LFFM_CODE};
 use regex::Regex;
 use std::sync::OnceLock;
 
@@ -8,7 +8,8 @@ use std::sync::OnceLock;
 /// Examples:
 ///   "LFBB-Bordeaux-260301-0003.sct"  → (LFBB, "2603")
 ///   "LFEE-Reims-260301-0003.ese"     → (LFEE, "2603")
-///   "LFFM-Base-260301-0003.sct"      → None (LFFM is rejected — legacy base)
+///   "LFFM-Military_…-260801-0001.sct" → None (LFFM is an area, not a FIR —
+///                                       use `parse_gng_sector_target`)
 ///   "garbage.sct"                    → None
 ///
 /// AIRAC encoding: the 6-digit middle group is taken as `YYMMSS` where the
@@ -24,23 +25,34 @@ pub fn parse_gng_sector_filename(name: &str) -> Option<(FirCode, Option<String>)
 /// sector file serves both the Paris (LFFF) and Reims (LFEE) FIRs.
 pub const LFXXN_CODE: &str = "LFXXN";
 
-/// Parse a GNG sector/profile filename into the *set* of FIRs it covers plus the
-/// AIRAC cycle. Unlike [`parse_gng_sector_filename`], a combined code such as
-/// `LFXXN` resolves to several FIRs (e.g. `LFXXN-Paris-Reims_…` → LFFF + LFEE).
-/// A regular `<FIR>-…` filename resolves to that single FIR.
+/// Parse a GNG sector/profile filename into the *set* of areas it covers plus
+/// the AIRAC cycle. Unlike [`parse_gng_sector_filename`], a combined code such as
+/// `LFXXN` resolves to several FIRs (e.g. `LFXXN-Paris-Reims_…` → LFFF + LFEE),
+/// and the non-FIR `LFFM` area is recognised too. A regular `<AREA>-…` filename
+/// resolves to that single area.
 ///
 /// Examples:
 ///   "LFXXN-Paris-Reims_20260605153747-260501-0001.sct" → ([LFFF, LFEE], "2605")
 ///   "LFBB-Bordeaux-260301-0003.sct"                    → ([LFBB], "2603")
-pub fn parse_gng_sector_target(name: &str) -> Option<(Vec<FirCode>, Option<String>)> {
-    // A combined code (e.g. LFXXN) takes precedence; no FIR code is a prefix of
-    // it, so the order relative to the single-FIR check is not load-bearing.
-    let firs = if let Some(combined) = leading_combined_code(name) {
-        combined.to_vec()
+///   "LFFM-Military_20260807195057-260801-0001.sct"     → ([LFFM], "2608")
+pub fn parse_gng_sector_target(name: &str) -> Option<(Vec<AreaCode>, Option<String>)> {
+    // A combined code (e.g. LFXXN) takes precedence; no area code is a prefix of
+    // it, so the order relative to the single-area check is not load-bearing.
+    let areas = if let Some(combined) = leading_combined_code(name) {
+        combined.iter().copied().map(AreaCode::Fir).collect()
     } else {
-        vec![leading_fir_code(name)?]
+        vec![leading_area_code(name)?]
     };
-    Some((firs, parse_airac_cycle(name)))
+    Some((areas, parse_airac_cycle(name)))
+}
+
+/// The single area a `<AREA>-…` / `<AREA>.…` filename targets: a FIR, or the
+/// military/legacy `LFFM` area, which ships its own sector file just like a FIR.
+pub fn leading_area_code(name: &str) -> Option<AreaCode> {
+    if has_leading_code(name, LFFM_CODE) {
+        return Some(AreaCode::Lffm);
+    }
+    leading_fir_code(name).map(AreaCode::Fir)
 }
 
 /// Extract the AIRAC cycle: the first 6-digit numeric group found between
@@ -64,37 +76,29 @@ fn parse_airac_cycle(name: &str) -> Option<String> {
 pub fn leading_combined_code(name: &str) -> Option<&'static [FirCode]> {
     const COMBINED: &[(&str, &[FirCode])] =
         &[(LFXXN_CODE, &[FirCode::LFFF, FirCode::LFEE])];
-    let upper = name.to_ascii_uppercase();
-    for (code, firs) in COMBINED {
-        if let Some(rest) = upper.strip_prefix(code) {
-            if rest.is_empty() || matches!(rest.chars().next(), Some('-' | '_' | ' ' | '.')) {
-                return Some(firs);
-            }
-        }
-    }
-    None
+    COMBINED
+        .iter()
+        .find(|(code, _)| has_leading_code(name, code))
+        .map(|(_, firs)| *firs)
 }
 
 static SIX_DIGIT_GROUP: OnceLock<Regex> = OnceLock::new();
 
-fn leading_fir_code(name: &str) -> Option<FirCode> {
+/// Whether `name` starts with `code` followed by either nothing, a separator
+/// (`-`, `_`, ` `) or a dot (for `LFBB.sct`-style names). The separator check is
+/// what keeps e.g. `LFXXNX-…` from matching `LFXXN`.
+fn has_leading_code(name: &str, code: &str) -> bool {
     let upper = name.to_ascii_uppercase();
-    // Reject the legacy LFFM base-pack prefix outright.
-    if upper.starts_with("LFFM") {
-        return None;
+    match upper.strip_prefix(code) {
+        Some(rest) => rest.is_empty() || matches!(rest.chars().next(), Some('-' | '_' | ' ' | '.')),
+        None => false,
     }
-    // Match exactly one of the known FIR codes at the start, followed by
-    // either a separator (`-`, `_`, ` `) or a dot (for `LFBB.sct`-style).
-    for fir in FirCode::ALL {
-        let prefix = fir.as_str();
-        if upper.starts_with(prefix) {
-            let rest = &upper[prefix.len()..];
-            if rest.is_empty() || matches!(rest.chars().next(), Some('-' | '_' | ' ' | '.')) {
-                return Some(fir);
-            }
-        }
-    }
-    None
+}
+
+fn leading_fir_code(name: &str) -> Option<FirCode> {
+    FirCode::ALL
+        .into_iter()
+        .find(|fir| has_leading_code(name, fir.as_str()))
 }
 
 fn cycle_from_six_digits(six: &str) -> String {
@@ -121,8 +125,12 @@ mod tests {
     }
 
     #[test]
-    fn rejects_lffm_legacy_base() {
-        assert!(parse_gng_sector_filename("LFFM-Base-260301-0003.sct").is_none());
+    fn lffm_is_not_a_fir() {
+        // The FIR-only parser must not claim LFFM; it is an area of its own and
+        // is resolved by `parse_gng_sector_target`.
+        assert!(
+            parse_gng_sector_filename("LFFM-Military_20260807195057-260801-0001.sct").is_none()
+        );
     }
 
     #[test]
@@ -158,17 +166,17 @@ mod tests {
         // The real GNG combined name embeds an `_`-prefixed 14-digit creation
         // timestamp before the AIRAC group; the cycle must be the `-260501-`
         // group (→ 2605), not any 6 digits of the timestamp.
-        let (firs, cycle) =
+        let (areas, cycle) =
             parse_gng_sector_target("LFXXN-Paris-Reims_20260605153747-260501-0001.sct").unwrap();
-        assert_eq!(firs, vec![FirCode::LFFF, FirCode::LFEE]);
+        assert_eq!(areas, vec![AreaCode::Fir(FirCode::LFFF), AreaCode::Fir(FirCode::LFEE)]);
         assert_eq!(cycle.as_deref(), Some("2605"));
     }
 
     #[test]
     fn combined_lfxxn_ese_variant() {
-        let (firs, cycle) =
+        let (areas, cycle) =
             parse_gng_sector_target("LFXXN-Paris-Reims_20260605153747-260501-0001.ese").unwrap();
-        assert_eq!(firs, vec![FirCode::LFFF, FirCode::LFEE]);
+        assert_eq!(areas, vec![AreaCode::Fir(FirCode::LFFF), AreaCode::Fir(FirCode::LFEE)]);
         assert_eq!(cycle.as_deref(), Some("2605"));
     }
 
@@ -181,10 +189,35 @@ mod tests {
 
     #[test]
     fn sector_target_falls_back_to_single_fir() {
-        let (firs, cycle) =
+        let (areas, cycle) =
             parse_gng_sector_target("LFBB-Bordeaux-260301-0003.sct").unwrap();
-        assert_eq!(firs, vec![FirCode::LFBB]);
+        assert_eq!(areas, vec![AreaCode::Fir(FirCode::LFBB)]);
         assert_eq!(cycle.as_deref(), Some("2603"));
+    }
+
+    #[test]
+    fn lffm_is_a_sector_target_of_its_own() {
+        // LFFM is not an ICAO FIR, but it owns `LFXX/Sectors/LFFM.sct` just like
+        // a FIR owns its own — `CoFrance LFFM.prf` reads it from there. Real GNG
+        // name, with the `_`-prefixed 14-digit creation timestamp before the
+        // `-260801-` AIRAC group.
+        let (areas, cycle) =
+            parse_gng_sector_target("LFFM-Military_20260807195057-260801-0001.sct").unwrap();
+        assert_eq!(areas, vec![AreaCode::Lffm]);
+        assert_eq!(cycle.as_deref(), Some("2608"));
+    }
+
+    #[test]
+    fn lffm_ese_variant() {
+        let (areas, cycle) =
+            parse_gng_sector_target("LFFM-Military_20260807195057-260801-0001.ese").unwrap();
+        assert_eq!(areas, vec![AreaCode::Lffm]);
+        assert_eq!(cycle.as_deref(), Some("2608"));
+    }
+
+    #[test]
+    fn lffm_area_requires_separator() {
+        assert!(parse_gng_sector_target("LFFMX-Random.sct").is_none());
     }
 
     #[test]

--- a/installer/core/src/pack_sync/integration_test.rs
+++ b/installer/core/src/pack_sync/integration_test.rs
@@ -99,6 +99,24 @@ fn build_fake_lfxxn_package() -> (TempDir, PathBuf) {
     (tmp, root)
 }
 
+/// The LFFM ("military / legacy") package. LFFM is not an ICAO FIR, but its area
+/// folder is shaped exactly like a FIR's: `CoFrance LFFM.prf` reads
+/// `\..\LFXX\Sectors\LFFM.sct` plus its own `\ICAO\…` / `\NavData\…`. Uses the
+/// real GNG filename shape, with an `_`-prefixed creation timestamp before the
+/// `-260801-` AIRAC group.
+fn build_fake_lffm_package() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+
+    write_file(&root, "LFFM-Military_20260807195057-260801-0001.sct", "military sct\n");
+    write_file(&root, "LFFM-Military_20260807195057-260801-0001.ese", "military ese\n");
+    write_file(&root, "LFFM-Military_20260807195057-260801-0001.rwy", "military rwy\n");
+    write_file(&root, "LFFM/ICAO/airports.txt", "lffm airports\n");
+    write_file(&root, "LFFM/NavData/airways.txt", "lffm navdata\n");
+
+    (tmp, root)
+}
+
 fn build_existing_install() -> TempDir {
     let tmp = TempDir::new().unwrap();
     let install_root = tmp.path();
@@ -311,6 +329,60 @@ fn lffm_is_installed_when_its_package_is_present() {
         files.contains(&"LFFM/Secret.txt".to_string()),
         "LFFM GitHub folder should be installed when its package is present; got: {files:#?}"
     );
+}
+
+#[test]
+fn lffm_package_installs_its_sector_files() {
+    let (_gh_tmp, github_root) = build_fake_github_repo();
+    let (_pkg_tmp, pkg_root) = build_fake_lffm_package();
+    let install_tmp = TempDir::new().unwrap();
+    let install_root = install_tmp.path();
+
+    let gng_roots = vec![pkg_root.clone()];
+    let summary = apply(
+        install_root,
+        &plan(PlanInputs {
+            github_root: Some(&github_root),
+            gng_roots: &gng_roots,
+            install_root,
+            github_short_sha: Some("abcdef1".into()),
+            area_source: AreaSource::Packages,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let files = list_files(install_root);
+
+    // LFFM owns a sector file exactly like a FIR does — its .prf points at
+    // `\..\LFXX\Sectors\LFFM.sct`.
+    assert!(
+        files.contains(&"LFXX/Sectors/LFFM.sct".to_string()),
+        "got: {files:#?}"
+    );
+    assert!(
+        files.contains(&"LFXX/Sectors/LFFM.ese".to_string()),
+        "got: {files:#?}"
+    );
+    assert!(
+        files.contains(&"LFXX/Sectors/LFFM.rwy".to_string()),
+        "got: {files:#?}"
+    );
+    assert_eq!(summary.airac_cycle.as_deref(), Some("2608"));
+
+    // ICAO/NavData land in LFFM's own folder (its .prf reads `\ICAO\…`) and are
+    // mirrored into LFXX like every other area's.
+    assert!(
+        files.contains(&"LFFM/ICAO/airports.txt".to_string()),
+        "got: {files:#?}"
+    );
+    assert!(
+        files.contains(&"LFXX/ICAO/airports.txt".to_string()),
+        "got: {files:#?}"
+    );
+
+    // Its GitHub overlay is installed, since the package selects the area.
+    assert!(files.contains(&"LFFM/Secret.txt".to_string()), "got: {files:#?}");
 }
 
 #[test]

--- a/installer/core/src/pack_sync/plan.rs
+++ b/installer/core/src/pack_sync/plan.rs
@@ -1,7 +1,7 @@
 use super::airac::{leading_combined_code, parse_gng_sector_target, LFXXN_CODE};
 use super::ownership::{gng_owned_set, is_gng_owned};
 use super::{COPYRIGHT_FILE, CURRENT_AIRAC_FILE, SECTORS_SUBPATH, SECTOR_BACKUP_DIRNAME};
-use crate::fir::FirCode;
+use crate::fir::{AreaCode, FirCode};
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -15,8 +15,8 @@ pub enum FileOp {
     /// Move an existing installed sector file to the backup directory before
     /// writing a new one in its place.
     BackupSector { src: PathBuf, dst: PathBuf },
-    /// Write a sector file to its canonical location, renamed to <FIR>.<ext>.
-    WriteSector { src: PathBuf, dst: PathBuf, fir: FirCode, ext: SectorExt },
+    /// Write a sector file to its canonical location, renamed to <AREA>.<ext>.
+    WriteSector { src: PathBuf, dst: PathBuf, area: AreaCode, ext: SectorExt },
     /// Move a `.prf` file to the FIR folder root.
     MoveProfile { src: PathBuf, dst: PathBuf },
     /// Write/overwrite a marker text file with a given string value.
@@ -72,9 +72,10 @@ pub struct SyncSummary {
     pub warnings: Vec<String>,
 }
 
-/// The legacy/Tier-2 "secret" area folder. It lives on GitHub but is only
-/// installed when a matching package is selected (see `detect_installed_codes`).
-pub const LFFM_CODE: &str = "LFFM";
+// The military/legacy Tier-2 "secret" area folder. It lives on GitHub but is
+// only installed when a matching package is selected (see
+// `detect_installed_codes`).
+pub use crate::fir::LFFM_CODE;
 
 /// How the set of areas (FIR folders + LFFM) to install is determined.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -164,8 +165,8 @@ fn detect_installed_areas_on_disk(install_root: &Path) -> (BTreeSet<FirCode>, bo
     (firs, lffm)
 }
 
-/// If `rel` is `<FIR>/ICAO/…` or `<FIR>/NavData/…`, the equivalent path under
-/// `LFXX` (CoFrance reads ICAO/NavData from `LFXX`, not the per-FIR folder).
+/// If `rel` is `<AREA>/ICAO/…` or `<AREA>/NavData/…`, the equivalent path under
+/// `LFXX` (CoFrance reads ICAO/NavData from `LFXX`, not the per-area folder).
 fn mirror_navdata_to_lfxx(rel: &Path) -> Option<PathBuf> {
     let parts: Vec<_> = rel.iter().collect();
     if parts.len() < 2 {
@@ -173,9 +174,9 @@ fn mirror_navdata_to_lfxx(rel: &Path) -> Option<PathBuf> {
     }
     let first = parts[0].to_string_lossy();
     let second = parts[1].to_string_lossy();
-    let is_fir = first.parse::<FirCode>().is_ok();
+    let is_area = first.parse::<AreaCode>().is_ok();
     let is_navdata = second.eq_ignore_ascii_case("ICAO") || second.eq_ignore_ascii_case("NavData");
-    if is_fir && is_navdata {
+    if is_area && is_navdata {
         let tail: PathBuf = parts[1..].iter().collect();
         Some(Path::new("LFXX").join(tail))
     } else {
@@ -228,7 +229,7 @@ pub fn plan(inputs: PlanInputs<'_>) -> anyhow::Result<SyncPlan> {
     //    writes are collected separately so they can be ordered AFTER their
     //    matching BackupSector ops in step 3.
     let mut sector_writes: Vec<FileOp> = Vec::new();
-    let mut sector_targets: BTreeSet<(FirCode, SectorExt)> = BTreeSet::new();
+    let mut sector_targets: BTreeSet<(AreaCode, SectorExt)> = BTreeSet::new();
     for gng_root in inputs.gng_roots {
         plan_gng_overlay(
             gng_root,
@@ -241,9 +242,9 @@ pub fn plan(inputs: PlanInputs<'_>) -> anyhow::Result<SyncPlan> {
 
     // Filter no-op sector writes (src content matches the file already at dst).
     sector_writes.retain(|op| match op {
-        FileOp::WriteSector { src, dst, fir, ext } => {
+        FileOp::WriteSector { src, dst, area, ext } => {
             if files_equal(src, dst) {
-                sector_targets.remove(&(*fir, *ext));
+                sector_targets.remove(&(*area, *ext));
                 false
             } else {
                 true
@@ -388,7 +389,7 @@ fn plan_gng_overlay(
     install_root: &Path,
     plan: &mut SyncPlan,
     sector_writes: &mut Vec<FileOp>,
-    sector_targets: &mut BTreeSet<(FirCode, SectorExt)>,
+    sector_targets: &mut BTreeSet<(AreaCode, SectorExt)>,
 ) {
     let sectors_dir = install_root.join(SECTORS_SUBPATH);
 
@@ -402,39 +403,39 @@ fn plan_gng_overlay(
             .extension()
             .map(|e| e.to_string_lossy().to_ascii_lowercase());
 
-        // Sector files: rename to <FIR>.<ext>, place in LFXX/Sectors/. A combined
-        // code (e.g. LFXXN) fans the single source file out to one renamed sector
-        // per covered FIR.
+        // Sector files: rename to <AREA>.<ext>, place in LFXX/Sectors/. A
+        // combined code (e.g. LFXXN) fans the single source file out to one
+        // renamed sector per covered FIR.
         if let Some(ext) = ext.as_deref().and_then(SectorExt::from_str) {
-            if let Some((firs, cycle)) = parse_gng_sector_target(&name) {
+            if let Some((areas, cycle)) = parse_gng_sector_target(&name) {
                 if let Some(c) = cycle.clone() {
                     plan.detected_airac = Some(c);
                 }
-                for fir in firs {
-                    let dst = sectors_dir.join(format!("{}.{}", fir.as_str(), ext.as_str()));
+                for area in areas {
+                    let dst = sectors_dir.join(format!("{}.{}", area.as_str(), ext.as_str()));
                     sector_writes.push(FileOp::WriteSector {
                         src: path.to_path_buf(),
                         dst,
-                        fir,
+                        area,
                         ext,
                     });
-                    sector_targets.insert((fir, ext));
+                    sector_targets.insert((area, ext));
                 }
                 continue;
             }
-            // Not a FIR sector filename — skip (e.g. sub-sector includes). This
+            // Not an area sector filename — skip (e.g. sub-sector includes). This
             // is expected, so it's a diagnostic note rather than a warning.
             plan.notes
-                .push(format!("Ignored non-FIR sector file: {}", name));
+                .push(format!("Ignored non-area sector file: {}", name));
             continue;
         }
 
-        // `.rwy` files: keep, paired with the sector dir as <FIR>.rwy. A combined
+        // `.rwy` files: keep, paired with the sector dir as <AREA>.rwy. A combined
         // code fans the single source out to one <FIR>.rwy per covered FIR.
         if ext.as_deref() == Some("rwy") {
-            if let Some((firs, _)) = parse_gng_sector_target(&name) {
-                for fir in firs {
-                    let dst = sectors_dir.join(format!("{}.rwy", fir.as_str()));
+            if let Some((areas, _)) = parse_gng_sector_target(&name) {
+                for area in areas {
+                    let dst = sectors_dir.join(format!("{}.rwy", area.as_str()));
                     plan.ops.push(FileOp::Copy {
                         src: path.to_path_buf(),
                         dst,
@@ -471,13 +472,18 @@ fn plan_gng_overlay(
 }
 
 /// Returns the destination-relative path(s) for a GNG file, anchored at the
-/// first FIR / LFXX / combined-code segment encountered in the package.
+/// first area / LFXX / combined-code segment encountered in the package.
 ///
 /// Most files yield a single destination. A combined `LFXXN` segment fans the
 /// file out to BOTH covered FIRs (LFFF + LFEE) — the same way the combined
 /// sector file is written once per FIR — so its `ICAO`/`NavData` and
 /// `Settings/VoiceChannels.txt` land under each FIR folder. Returns an empty
 /// vec when no anchor segment exists.
+///
+/// `LFFM` anchors like any other area (it is not rewritten into `LFXX`): its
+/// `.prf` reads `\ICAO\…` / `\NavData\…` relative to its own folder, exactly as
+/// each FIR's does. The `LFXX` copy CoFrance reads still gets written, via
+/// [`mirror_navdata_to_lfxx`].
 fn locate_inside_fir_or_lfxx(gng_root: &Path, path: &Path) -> Vec<PathBuf> {
     let Ok(rel) = path.strip_prefix(gng_root) else {
         return Vec::new();
@@ -487,7 +493,7 @@ fn locate_inside_fir_or_lfxx(gng_root: &Path, path: &Path) -> Vec<PathBuf> {
         let segment = part.to_string_lossy();
         let upper = segment.to_ascii_uppercase();
 
-        if upper == "LFXX" || FirCode::ALL.iter().any(|fir| fir.as_str() == upper.as_str()) {
+        if upper == "LFXX" || upper.parse::<AreaCode>().is_ok() {
             let tail: PathBuf = parts[idx..].iter().collect();
             return vec![tail];
         }
@@ -502,22 +508,13 @@ fn locate_inside_fir_or_lfxx(gng_root: &Path, path: &Path) -> Vec<PathBuf> {
                 .map(|fir| Path::new(fir.as_str()).join(&tail))
                 .collect();
         }
-
-        if upper == "LFFM" {
-            // Legacy: rewrite LFFM into LFXX.
-            let mut p = PathBuf::from("LFXX");
-            for tail_part in &parts[idx + 1..] {
-                p.push(tail_part);
-            }
-            return vec![p];
-        }
     }
     Vec::new()
 }
 
 fn plan_sector_backups(
     install_root: &Path,
-    sector_targets: &BTreeSet<(FirCode, SectorExt)>,
+    sector_targets: &BTreeSet<(AreaCode, SectorExt)>,
     previous_airac: Option<&str>,
     plan: &mut SyncPlan,
 ) {
@@ -528,16 +525,17 @@ fn plan_sector_backups(
         path: backup_dir.clone(),
     });
 
-    for (fir, ext) in sector_targets {
-        let existing = sectors_dir.join(format!("{}.{}", fir.as_str(), ext.as_str()));
+    for (area, ext) in sector_targets {
+        let existing = sectors_dir.join(format!("{}.{}", area.as_str(), ext.as_str()));
         if existing.exists() {
             let cycle = previous_airac.unwrap_or("unknown");
-            let mut backup = backup_dir.join(format!("{}-{}.{}", fir.as_str(), cycle, ext.as_str()));
+            let mut backup =
+                backup_dir.join(format!("{}-{}.{}", area.as_str(), cycle, ext.as_str()));
             if backup.exists() {
                 let ts = chrono::Utc::now().format("%Y%m%d_%H%M%S").to_string();
                 backup = backup_dir.join(format!(
                     "{}-{}_{}.{}",
-                    fir.as_str(),
+                    area.as_str(),
                     cycle,
                     ts,
                     ext.as_str()

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "controller-pack-installer",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/installer/src-tauri/src/profile_store/mod.rs
+++ b/installer/src-tauri/src/profile_store/mod.rs
@@ -5,7 +5,7 @@
 pub use controller_pack_core::profile_types::{
     InstalledVersions, Preferences, Profile, VatsimCredentials,
 };
-use controller_pack_core::FirCode;
+use controller_pack_core::AreaCode;
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_store::StoreExt;
@@ -30,8 +30,12 @@ pub fn save<R: Runtime>(app: &AppHandle<R>, profile: &Profile) -> anyhow::Result
 
 pub fn looks_like_controller_pack(path: &Path) -> bool {
     let has_lfxx = path.join("LFXX").is_dir();
-    let has_any_fir = FirCode::ALL.iter().any(|fir| path.join(fir.as_str()).is_dir());
-    has_lfxx && has_any_fir
+    // Any area folder counts, LFFM included — it is not a FIR, but a pack that
+    // only installed the military area is still a controller pack.
+    let has_any_area = AreaCode::ALL
+        .iter()
+        .any(|area| path.join(area.as_str()).is_dir());
+    has_lfxx && has_any_area
 }
 
 pub fn detect_pack_dir() -> Option<PathBuf> {
@@ -49,13 +53,22 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn looks_like_controller_pack_requires_lfxx_and_one_fir() {
+    fn looks_like_controller_pack_requires_lfxx_and_one_area() {
         let tmp = tempdir().unwrap();
         let root = tmp.path();
         assert!(!looks_like_controller_pack(root));
         std::fs::create_dir_all(root.join("LFXX")).unwrap();
         assert!(!looks_like_controller_pack(root));
         std::fs::create_dir_all(root.join("LFBB")).unwrap();
+        assert!(looks_like_controller_pack(root));
+    }
+
+    #[test]
+    fn lffm_only_pack_is_recognised() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("LFXX")).unwrap();
+        std::fs::create_dir_all(root.join("LFFM")).unwrap();
         assert!(looks_like_controller_pack(root));
     }
 }

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "French vACC Controller Pack Installer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "fr.vacc.controller-pack-installer",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Fixes #150.

## Cause

The installer modelled `LFFM` as a legacy alias of `LFXX`, but it is a normal area folder that simply is not an ICAO FIR. The GNG filename parser rejected any name starting with `LFFM` outright:

```rust
// Reject the legacy LFFM base-pack prefix outright.
if upper.starts_with("LFFM") { return None; }
```

So `LFFM-Military_20260807195057-260801-0001.sct` and its `.ese` were dropped as `"Ignored non-FIR sector file"` and never written to `LFXX/Sectors`. That matches the report exactly: everything else installed fine, because the area is still detected by name and its GitHub overlay (`.prf`, ASRs, Settings) was laid down normally — only the sectors were missing. `LFFM/CoFrance LFFM.prf:71` reads `\..\LFXX\Sectors\LFFM.sct`, so the profile pointed at nothing.

The same premise had a second effect, not in the report: `LFFM/ICAO/…` and `LFFM/NavData/…` from the package were rewritten into `LFXX/…`, yet that `.prf` reads `\ICAO\…` and `\NavData\…` relative to its own folder, exactly as all five FIR profiles do. Its aircraft, airline and airway data therefore landed nowhere it looks. Fixed here too, since it is the same misclassification — worth a second opinion if the LFXX-only routing was deliberate.

## Change

Adds `AreaCode` (`Fir(FirCode) | Lffm`) and keys sector planning on it instead of `FirCode`.

`LFFM` deliberately stays out of `FirCode` — it is not a FIR, and the GitHub overlay still gates it on its package being selected, so the area remains opt-in.

- `airac.rs` — `parse_gng_sector_target` returns `Vec<AreaCode>` and resolves `LFFM`. Prefix+separator matching is factored into one helper, so `LFFMX-…` still does not match (same rule that protects `LFXXN`).
- `plan.rs` — `WriteSector`, sector targets and backup naming keyed on `AreaCode`; `.sct`/`.ese`/`.rwy` land as `LFXX/Sectors/LFFM.*`. Drops the `LFFM → LFXX` path rewrite so ICAO/NavData go to `LFFM/`, with the `LFXX` mirror still written — LFXX content is unchanged, it is just no longer the only copy.
- `profile_store` — pack auto-detection accepts an `LFXX` + `LFFM` install.

## Testing

`cargo test --workspace` — 42 passed, 0 failed (was 38). `cargo clippy --workspace --all-targets` adds no new warnings.

Four new tests, written against the real GNG filename shape (`LFFM-Military_20260807195057-260801-0001.sct` → area `LFFM`, cycle `2608`; the `_`-prefixed creation timestamp is not mistaken for the AIRAC group). The integration test `lffm_package_installs_its_sector_files` asserts the sectors, the `.rwy`, the ICAO/NavData placement and the mirror, and fails on the pre-fix code.

Not tested against a real LFFM archive beyond that filename — any `LFFM`-prefixed name followed by `-`, `_`, ` ` or `.` resolves.


## Version

Bumped to `v0.1.2`. This is installer code, so per `RELEASE.md` clients only see the fix if `latest.json` carries a different version from the running app.

The bump also resyncs the three version files. `1aaae26` bumped only `tauri.conf.json` to `0.1.1` and left `Cargo.toml` and `package.json` at `0.1.0`. That has been harmless so far — the updater compares against the `tauri.conf.json` version baked into the binary, and the `CARGO_PKG_VERSION`-based `current_version` in `check_installer_update` has no call site in the frontend — but the drift would misreport once that banner is wired up. All three (plus `Cargo.lock`) now read `0.1.2`.
