### PR TITLE
installer: build and release for macOS

### DIFF
--- a/.github/workflows/build-installer-tauri.yml
+++ b/.github/workflows/build-installer-tauri.yml
@@ -1,14 +1,21 @@
 name: Build Installer (Tauri)
 
-# Builds the Windows x64 controller-pack installer and publishes the Tauri
-# auto-update artifacts (signed NSIS installer + latest.json) on release,
-# or uploads them as workflow artifacts on manual dispatch.
+# Builds the controller-pack installer for Windows x64 and macOS (universal)
+# and publishes the Tauri auto-update artifacts (signed NSIS installer, signed
+# .app.tar.gz + .dmg, and a single latest.json covering both platforms) on
+# release, or uploads them as workflow artifacts on manual dispatch.
 #
 # Auto-updates require these repository secrets:
 #   TAURI_SIGNING_PRIVATE_KEY           the Tauri updater private key
 #   TAURI_SIGNING_PRIVATE_KEY_PASSWORD  its password (empty string if none)
 # and the matching public key in installer/src-tauri/tauri.conf.json
 # (plugins.updater.pubkey). Generate the keypair with `bun tauri signer generate`.
+#
+# macOS code signing / notarization is OPTIONAL — without the secrets below the
+# app still builds and updates, it is just unsigned (users must right-click →
+# Open once, see installer/RELEASE.md):
+#   APPLE_CERTIFICATE / APPLE_CERTIFICATE_PASSWORD / APPLE_SIGNING_IDENTITY
+#   APPLE_ID / APPLE_PASSWORD / APPLE_TEAM_ID       (notarization, needs the above)
 
 on:
   push:
@@ -42,19 +49,25 @@ jobs:
         run: cargo test -p controller-pack-core --verbose
 
   smoke-build:
-    name: Linux smoke build
-    # Only run smoke build on PRs and pushes (saves time/cost on manual triggers & releases)
+    name: Smoke build (${{ matrix.os }})
+    # Only run smoke builds on PRs and pushes (saves time/cost on manual triggers & releases)
     if: github.event_name == 'push' || github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     needs: core-tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: installer
+          key: ${{ matrix.os }}
       - uses: oven-sh/setup-bun@v2
       - name: Install Linux system deps
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -72,6 +85,12 @@ jobs:
       - name: Rust check (Tauri crate)
         working-directory: installer/src-tauri
         run: cargo check --all-targets
+      # The core tests cover the non-Windows path handling (Wine-bottle pack
+      # detection, `\`-separated archive entries), so run them on a real mac too.
+      - name: Core tests
+        if: runner.os == 'macOS'
+        working-directory: installer
+        run: cargo test -p controller-pack-core
 
   release-build:
     name: Windows x64 installer
@@ -115,4 +134,82 @@ jobs:
           path: |
             installer/target/**/release/bundle/nsis/*.exe
             installer/target/**/release/bundle/nsis/*.nsis.zip*
+          retention-days: 7
+
+  release-build-macos:
+    name: macOS universal app
+    # Same triggers as the Windows job, but it runs *after* it: tauri-action
+    # merges each platform into the release's single `latest.json`, and two
+    # concurrent jobs rewriting that asset would lose one of the platforms.
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs: [core-tests, release-build]
+    runs-on: macos-latest
+    # `secrets` is not available in a step-level `if`, so the presence checks are
+    # hoisted here (job-level env *can* read secrets) and the steps test these.
+    env:
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
+      HAS_APPLE_NOTARIZATION: ${{ secrets.APPLE_CERTIFICATE != '' && secrets.APPLE_ID != '' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Both halves of the universal binary.
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: installer
+          key: macos-release
+      - uses: oven-sh/setup-bun@v2
+      - name: Frontend install
+        working-directory: installer
+        run: bun install
+
+      # Signing is optional: with no Apple Developer secrets configured the app
+      # is built unsigned and users get the Gatekeeper right-click → Open dance.
+      # The vars must stay *unset* rather than empty — the bundler treats an
+      # empty APPLE_CERTIFICATE as "sign with this", which fails the build.
+      - name: Enable Apple code signing
+        if: env.HAS_APPLE_CERT == 'true'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          for var in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY; do
+            printf '%s<<__EOF__\n%s\n__EOF__\n' "$var" "${!var}" >> "$GITHUB_ENV"
+          done
+      - name: Enable notarization
+        if: env.HAS_APPLE_NOTARIZATION == 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          for var in APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            printf '%s<<__EOF__\n%s\n__EOF__\n' "$var" "${!var}" >> "$GITHUB_ENV"
+          done
+
+      # Builds the universal .app + .dmg, signs the updater bundle, and merges
+      # the darwin-aarch64 / darwin-x86_64 entries into the release's latest.json.
+      - name: Build and compile (Tauri Action)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: installer
+          tagName: ${{ github.event.release.tag_name }}
+          releaseId: ${{ github.event.release.id }}
+          args: --target universal-apple-darwin
+          includeUpdaterJson: true
+
+      - name: Upload macOS Build Artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-installer-universal
+          path: |
+            installer/target/**/release/bundle/dmg/*.dmg
+            installer/target/**/release/bundle/macos/*.app.tar.gz*
           retention-days: 7

--- a/installer/Cargo.lock
+++ b/installer/Cargo.lock
@@ -413,7 +413,7 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "controller-pack-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "controller-pack-installer"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "controller-pack-core",

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["core", "src-tauri"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.77"
 

--- a/installer/RELEASE.md
+++ b/installer/RELEASE.md
@@ -38,9 +38,26 @@ Commit and push. Every subsequent build will be signed by the matching private k
 
 > ⚠️ **If you ever lose the private key, every existing installation is permanently orphaned** — they will refuse any update because they only trust manifests signed by that exact key. Back the key up in *at least* two places (e.g. password manager + offline encrypted USB).
 
+The same keypair signs **both** platforms' updater bundles — there is nothing extra to generate for macOS.
+
+### 4. (Optional) Apple code signing & notarization
+
+Entirely optional. Without it the macOS build still works and still auto-updates; it is just unsigned, so the **first** launch needs the Gatekeeper workaround (see [Installing the macOS build](#installing-the-macos-build)). With an Apple Developer Program membership ($99/yr), add these repository secrets and the workflow signs and notarizes automatically:
+
+| Secret | What it is |
+| --- | --- |
+| `APPLE_CERTIFICATE` | base64 of the exported *Developer ID Application* `.p12` (`base64 -i cert.p12 \| pbcopy`) |
+| `APPLE_CERTIFICATE_PASSWORD` | the password set when exporting the `.p12` |
+| `APPLE_SIGNING_IDENTITY` | optional cross-check, e.g. `Developer ID Application: Your Org (TEAMID)` — the bundler signs with the identity inside the `.p12`, and fails loudly if this doesn't match it |
+| `APPLE_ID` | Apple ID used for notarization |
+| `APPLE_PASSWORD` | an **app-specific password** for that Apple ID |
+| `APPLE_TEAM_ID` | the 10-character team ID |
+
+Signing switches on when `APPLE_CERTIFICATE` is present; notarization additionally requires `APPLE_ID`. Leave the secrets unset and the job silently produces an unsigned build — it must never be set to an empty string, which the bundler reads as "sign with this" and fails on.
+
 ## Cutting a release
 
-The pack ships as a **single combined release roughly once a month**. Any published GitHub Release — whether it carries AIRAC (sector) changes, installer changes, or both — triggers `.github/workflows/build-installer-tauri.yml`, which rebuilds, signs, and attaches the Windows x64 installer plus `latest.json` to that same release. There is no dedicated installer-only release stream and no special tag prefix; the workflow keys off the release event, not the tag name.
+The pack ships as a **single combined release roughly once a month**. Any published GitHub Release — whether it carries AIRAC (sector) changes, installer changes, or both — triggers `.github/workflows/build-installer-tauri.yml`, which rebuilds, signs, and attaches the Windows x64 installer, the macOS universal app, and a `latest.json` covering both to that same release. There is no dedicated installer-only release stream and no special tag prefix; the workflow keys off the release event, not the tag name.
 
 ### When the installer code changed
 
@@ -59,13 +76,33 @@ No version bump is needed. The release still rebuilds and re-signs the installer
 ### Publishing
 
 1. Tag and create the GitHub Release as usual for the monthly drop (use whatever tag the release uses — the workflow does not require a prefix).
-2. The `release-build` job runs only on `release: published`. It builds the Windows x64 NSIS installer with `tauri-action`, signs it, generates `latest.json`, and attaches everything to the release. (Linux is only a smoke build on non-release pushes/PRs — no Linux artifact is published.)
+2. Two jobs run on `release: published`, **in sequence**:
+   - `release-build` — the Windows x64 NSIS installer, signed, with a `latest.json` carrying the `windows-x86_64` entry.
+   - `release-build-macos` — a universal (Apple Silicon + Intel) `.app` and `.dmg`, signed, merging the `darwin-aarch64` and `darwin-x86_64` entries into that *same* `latest.json`.
+
+   They are sequenced on purpose: `tauri-action` rewrites the release's single `latest.json` asset, merging into whatever is already there, so running them concurrently would drop one platform. (Linux is only a smoke build on non-release pushes/PRs — no Linux artifact is published.)
 3. Verify the release assets contain:
    - `French vACC Controller Pack Installer_<version>_x64-setup.exe`
    - `French vACC Controller Pack Installer_<version>_x64-setup.exe.sig`
-   - `latest.json`
+   - `French vACC Controller Pack Installer_<version>_universal.dmg`
+   - `French vACC Controller Pack Installer_universal.app.tar.gz`
+   - `French vACC Controller Pack Installer_universal.app.tar.gz.sig`
+   - `latest.json` — open it and check it lists **three** platform keys: `windows-x86_64`, `darwin-aarch64`, `darwin-x86_64`. If the macOS keys are missing, the mac job failed or was skipped; re-run it and confirm the merge before announcing the release.
 
-The updater endpoint is `https://github.com/vaccfr/Sector-Files/releases/latest/download/latest.json` (configured in `tauri.conf.json` → `plugins.updater.endpoints`), so it always reads whatever the **latest** release published — there's no per-tag URL to update. End users with a previous Tauri installer (>= v0.1.0) see the new version offered the next time they launch the app (passive install on Windows).
+The updater endpoint is `https://github.com/vaccfr/Sector-Files/releases/latest/download/latest.json` (configured in `tauri.conf.json` → `plugins.updater.endpoints`), so it always reads whatever the **latest** release published — there's no per-tag URL to update. End users with a previous Tauri installer (>= v0.1.0) see the new version offered the next time they launch the app (passive install on Windows; on macOS the updater swaps the `.app` in place and relaunches).
+
+## Installing the macOS build
+
+EuroScope itself is Windows-only, so the mac build is for controllers who keep their pack in a Wine/CrossOver/Whisky bottle (or sync it by hand). The installer finds those automatically — it scans `~/Documents`, `~/Desktop`, `~`, and the `Documents` folder of every Windows user inside every bottle it can find — but the directory can always be picked manually.
+
+Users install by opening the `.dmg` and dragging the app to `/Applications`.
+
+**While the build is unsigned**, macOS quarantines it and the first launch fails with *"…is damaged and can't be opened"*. Tell users to either:
+
+- right-click (or ⌃-click) the app → **Open** → **Open** in the dialog, or
+- run once: `xattr -dr com.apple.quarantine "/Applications/French vACC Controller Pack Installer.app"`
+
+This is only needed for the first launch; auto-updates afterwards are unaffected (the updater downloads without setting the quarantine flag). Configuring the Apple secrets above removes the workaround entirely.
 
 ## Rolling back
 

--- a/installer/core/src/archive_paths.rs
+++ b/installer/core/src/archive_paths.rs
@@ -1,0 +1,160 @@
+//! Fixing up archives that store Windows path separators.
+//!
+//! AeroNav/GNG packages are produced on Windows, and some archivers write the
+//! entry names with `\` separators. Extracting such an archive on Windows yields
+//! real nested directories; on macOS/Linux `\` is an ordinary filename
+//! character, so the whole package lands as a handful of files literally named
+//! `LFBB\ICAO\LFBB.txt` — the planner then walks the tree, finds no `LFBB`
+//! folder and no sector files, and silently installs nothing.
+//!
+//! [`normalize_windows_separators`] rewrites those entries into the nested paths
+//! they were meant to be. It is a no-op on Windows (where `\` cannot appear in a
+//! filename) and on archives that already use `/`.
+
+use std::path::{Component, Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Split a `\`-separated name into path components, dropping anything that
+/// would escape the extraction root (`..`, absolute prefixes, drive letters).
+fn safe_nested_path(name: &str) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for segment in name.split('\\') {
+        let segment = segment.trim();
+        if segment.is_empty() || segment == "." {
+            continue;
+        }
+        // `..`, `C:` and friends: refuse the whole entry rather than guess.
+        if segment == ".." || segment.ends_with(':') {
+            return None;
+        }
+        out.push(segment);
+    }
+    if out.components().count() < 2 {
+        return None;
+    }
+    // Belt and braces: reject anything that is not a plain relative path.
+    if !out.components().all(|c| matches!(c, Component::Normal(_))) {
+        return None;
+    }
+    Some(out)
+}
+
+/// Rewrite every file under `root` whose name embeds `\` separators into the
+/// equivalent nested path. Returns how many files were moved.
+///
+/// Directories left empty by the moves are kept — they hold no files, so the
+/// planner ignores them.
+pub fn normalize_windows_separators(root: &Path) -> std::io::Result<usize> {
+    // Collect first: renaming while walking would invalidate the iterator.
+    let mut moves: Vec<(PathBuf, PathBuf)> = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy();
+        if !name.contains('\\') {
+            continue;
+        }
+        let Some(nested) = safe_nested_path(&name) else {
+            tracing::warn!(entry = %entry.path().display(), "skipping unsafe archive entry name");
+            continue;
+        };
+        let parent = entry.path().parent().unwrap_or(root);
+        moves.push((entry.path().to_path_buf(), parent.join(nested)));
+    }
+
+    let mut moved = 0usize;
+    for (src, dst) in moves {
+        if dst.exists() {
+            // Two entries claim the same destination — keep the first and leave
+            // the duplicate where it is rather than losing data silently.
+            tracing::warn!(dst = %dst.display(), "archive entry collides with an existing file");
+            continue;
+        }
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::rename(&src, &dst)?;
+        moved += 1;
+    }
+    Ok(moved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_names_are_left_alone() {
+        assert_eq!(safe_nested_path("LFBB.sct"), None);
+        assert_eq!(safe_nested_path("no-separators-here"), None);
+    }
+
+    #[test]
+    fn nested_names_split_into_components() {
+        assert_eq!(
+            safe_nested_path("LFBB\\ICAO\\LFBB.txt"),
+            Some(PathBuf::from("LFBB").join("ICAO").join("LFBB.txt"))
+        );
+    }
+
+    #[test]
+    fn traversal_and_absolute_names_are_refused() {
+        assert_eq!(safe_nested_path("..\\..\\evil.txt"), None);
+        assert_eq!(safe_nested_path("C:\\Windows\\evil.txt"), None);
+        assert_eq!(safe_nested_path("LFBB\\..\\..\\evil.txt"), None);
+    }
+
+    // `\` cannot appear in a Windows filename, so the on-disk half of the
+    // behaviour is only observable (and only needed) elsewhere.
+    #[cfg(not(windows))]
+    mod on_disk {
+        use super::*;
+        use std::fs;
+        use tempfile::tempdir;
+
+        #[test]
+        fn windows_style_entries_become_real_directories() {
+            let tmp = tempdir().unwrap();
+            let root = tmp.path();
+            fs::write(root.join("LFBB\\ICAO\\LFBB.txt"), b"icao").unwrap();
+            fs::write(root.join("LFBB\\Settings\\VoiceChannels.txt"), b"voice").unwrap();
+            fs::write(root.join("LFBB-Bordeaux-260301-0003.sct"), b"sector").unwrap();
+
+            assert_eq!(normalize_windows_separators(root).unwrap(), 2);
+
+            assert_eq!(
+                fs::read_to_string(root.join("LFBB/ICAO/LFBB.txt")).unwrap(),
+                "icao"
+            );
+            assert_eq!(
+                fs::read_to_string(root.join("LFBB/Settings/VoiceChannels.txt")).unwrap(),
+                "voice"
+            );
+            // Untouched, and no second pass needed.
+            assert!(root.join("LFBB-Bordeaux-260301-0003.sct").is_file());
+            assert_eq!(normalize_windows_separators(root).unwrap(), 0);
+        }
+
+        #[test]
+        fn nested_below_an_already_extracted_folder() {
+            let tmp = tempdir().unwrap();
+            let root = tmp.path();
+            fs::create_dir_all(root.join("package")).unwrap();
+            fs::write(root.join("package").join("LFRR\\NavData\\wpt.txt"), b"x").unwrap();
+
+            assert_eq!(normalize_windows_separators(root).unwrap(), 1);
+            assert!(root.join("package/LFRR/NavData/wpt.txt").is_file());
+        }
+
+        #[test]
+        fn unsafe_entries_are_left_in_place() {
+            let tmp = tempdir().unwrap();
+            let root = tmp.path();
+            fs::write(root.join("..\\escape.txt"), b"x").unwrap();
+
+            assert_eq!(normalize_windows_separators(root).unwrap(), 0);
+            assert!(root.join("..\\escape.txt").is_file());
+        }
+    }
+}

--- a/installer/core/src/lib.rs
+++ b/installer/core/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod archive_paths;
 pub mod fir;
+pub mod pack_dir;
 pub mod pack_sync;
 pub mod profile_configurator;
 pub mod profile_types;

--- a/installer/core/src/pack_dir.rs
+++ b/installer/core/src/pack_dir.rs
@@ -1,0 +1,227 @@
+//! Recognising a controller-pack install root, and guessing where it lives.
+//!
+//! EuroScope itself is Windows-only, so on macOS the pack is either a plain
+//! folder the user syncs by hand or — far more often — a folder inside a
+//! Wine/CrossOver/Whisky bottle's `drive_c`. The detection below therefore
+//! looks at the usual native locations *and* at the `Documents` folder of every
+//! Windows user inside every bottle it can find.
+//!
+//! Everything here takes its roots as arguments so it can be unit-tested
+//! against a fake home directory; [`detect_pack_dir`] is the thin wrapper that
+//! reads the real environment.
+
+use crate::fir::AreaCode;
+use std::path::{Path, PathBuf};
+
+/// A directory is a controller pack when it has `LFXX` plus at least one area
+/// folder. Any area counts, `LFFM` included — it is not a FIR, but a pack that
+/// only installed the military area is still a controller pack.
+pub fn looks_like_controller_pack(path: &Path) -> bool {
+    let has_lfxx = path.join("LFXX").is_dir();
+    let has_any_area = AreaCode::ALL
+        .iter()
+        .any(|area| path.join(area.as_str()).is_dir());
+    has_lfxx && has_any_area
+}
+
+/// Wine-style prefixes to look inside, in preference order. A prefix is a
+/// directory containing `drive_c`; the bottle managers keep theirs one level
+/// below a `Bottles` directory.
+fn wine_prefixes(home: &Path) -> Vec<PathBuf> {
+    let mut prefixes = vec![home.join(".wine")];
+
+    let bottle_roots = [
+        // CrossOver
+        home.join("Library/Application Support/CrossOver/Bottles"),
+        // Whisky
+        home.join("Library/Containers/com.isaacmarovitz.Whisky/Bottles"),
+        // Plain wine / winetricks conventions
+        home.join(".local/share/wineprefixes"),
+    ];
+    for root in bottle_roots {
+        let Ok(entries) = std::fs::read_dir(&root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                prefixes.push(entry.path());
+            }
+        }
+    }
+    prefixes.retain(|p| p.join("drive_c").is_dir());
+    prefixes
+}
+
+/// The `Documents` folder of every Windows user inside a Wine prefix.
+fn wine_document_dirs(home: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    for prefix in wine_prefixes(home) {
+        let users = prefix.join("drive_c").join("users");
+        let Ok(entries) = std::fs::read_dir(&users) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            // `Public` holds no per-user Documents worth scanning.
+            if entry.file_name().to_string_lossy().eq_ignore_ascii_case("Public") {
+                continue;
+            }
+            dirs.push(entry.path().join("Documents"));
+            dirs.push(entry.path().join("My Documents"));
+        }
+    }
+    dirs
+}
+
+/// Directories worth scanning for a controller pack, most likely first. Each is
+/// checked both as a pack itself and as a parent holding one (e.g.
+/// `Documents/EuroScope`), so no folder *names* need to be guessed.
+pub fn pack_dir_search_roots(home: &Path) -> Vec<PathBuf> {
+    let mut roots = vec![
+        home.join("Documents"),
+        home.join("Desktop"),
+        home.to_path_buf(),
+    ];
+    // Wine bottles only exist off Windows; skip the directory scan there.
+    if !cfg!(windows) {
+        roots.extend(wine_document_dirs(home));
+    }
+    roots
+}
+
+/// First directory that looks like a controller pack: the current directory (the
+/// legacy layout put the installer *inside* the pack), then each search root and
+/// its immediate children.
+pub fn detect_pack_dir_in(cwd: Option<&Path>, home: Option<&Path>) -> Option<PathBuf> {
+    if let Some(cwd) = cwd {
+        if looks_like_controller_pack(cwd) {
+            return Some(cwd.to_path_buf());
+        }
+    }
+    let home = home?;
+    for root in pack_dir_search_roots(home) {
+        if looks_like_controller_pack(&root) {
+            return Some(root);
+        }
+        let Ok(entries) = std::fs::read_dir(&root) else {
+            continue;
+        };
+        let mut children: Vec<PathBuf> = entries
+            .flatten()
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .map(|e| e.path())
+            .collect();
+        // Stable order so the same install is picked every run.
+        children.sort();
+        if let Some(found) = children.into_iter().find(|c| looks_like_controller_pack(c)) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// The user's home directory, from the environment.
+pub fn home_dir() -> Option<PathBuf> {
+    let var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    std::env::var_os(var).map(PathBuf::from).filter(|p| !p.as_os_str().is_empty())
+}
+
+/// [`detect_pack_dir_in`] against the real current directory and home.
+pub fn detect_pack_dir() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok();
+    detect_pack_dir_in(cwd.as_deref(), home_dir().as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn make_pack(root: &Path) {
+        fs::create_dir_all(root.join("LFXX")).unwrap();
+        fs::create_dir_all(root.join("LFBB")).unwrap();
+    }
+
+    #[test]
+    fn looks_like_controller_pack_requires_lfxx_and_one_area() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        assert!(!looks_like_controller_pack(root));
+        fs::create_dir_all(root.join("LFXX")).unwrap();
+        assert!(!looks_like_controller_pack(root));
+        fs::create_dir_all(root.join("LFBB")).unwrap();
+        assert!(looks_like_controller_pack(root));
+    }
+
+    #[test]
+    fn lffm_only_pack_is_recognised() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        fs::create_dir_all(root.join("LFXX")).unwrap();
+        fs::create_dir_all(root.join("LFFM")).unwrap();
+        assert!(looks_like_controller_pack(root));
+    }
+
+    #[test]
+    fn search_roots_always_include_documents_desktop_and_home() {
+        let home = Path::new("/fake/home");
+        let roots = pack_dir_search_roots(home);
+        assert!(roots.contains(&home.join("Documents")));
+        assert!(roots.contains(&home.join("Desktop")));
+        assert!(roots.contains(&home.to_path_buf()));
+    }
+
+    #[test]
+    fn current_directory_wins_when_it_is_a_pack() {
+        let tmp = tempdir().unwrap();
+        let cwd = tmp.path().join("cwd");
+        make_pack(&cwd);
+        let home = tmp.path().join("home");
+        make_pack(&home.join("Documents/EuroScope"));
+
+        assert_eq!(detect_pack_dir_in(Some(&cwd), Some(&home)), Some(cwd));
+    }
+
+    #[test]
+    fn finds_pack_one_level_under_documents() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path();
+        let pack = home.join("Documents").join("EuroScope");
+        make_pack(&pack);
+        fs::create_dir_all(home.join("Documents").join("Unrelated")).unwrap();
+
+        assert_eq!(detect_pack_dir_in(None, Some(home)), Some(pack));
+    }
+
+    #[test]
+    fn returns_none_when_nothing_looks_like_a_pack() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("Documents/Whatever")).unwrap();
+        assert_eq!(detect_pack_dir_in(None, Some(tmp.path())), None);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn finds_pack_inside_a_crossover_bottle() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path();
+        let pack = home
+            .join("Library/Application Support/CrossOver/Bottles/EuroScope")
+            .join("drive_c/users/crossover/Documents/CoFrance");
+        make_pack(&pack);
+
+        assert_eq!(detect_pack_dir_in(None, Some(home)), Some(pack));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn wine_prefixes_without_drive_c_are_ignored() {
+        let tmp = tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("Library/Application Support/CrossOver/Bottles/Empty")).unwrap();
+        assert!(wine_prefixes(home).is_empty());
+    }
+}

--- a/installer/core/src/pack_sync/apply.rs
+++ b/installer/core/src/pack_sync/apply.rs
@@ -117,11 +117,13 @@ fn atomic_copy(src: &Path, dst: &Path) -> io::Result<()> {
     ));
     fs::copy(src, &tmp)?;
     if let Err(e) = fs::rename(&tmp, dst) {
-        // On Windows, rename across the same dir works; if rename fails (e.g.
-        // dst exists with file lock), fall back to direct copy.
+        // Rename within a directory is atomic on every platform we ship, but it
+        // can still fail (a locked destination on Windows, a filesystem that
+        // refuses the rename). Falling back to a direct copy loses atomicity,
+        // not correctness — so it is a success, not an error.
+        tracing::debug!(dst = %dst.display(), error = %e, "atomic rename failed; copying in place");
         fs::copy(src, dst)?;
         let _ = fs::remove_file(&tmp);
-        return Err(e);
     }
     Ok(())
 }
@@ -130,9 +132,9 @@ fn atomic_write(dst: &Path, bytes: &[u8]) -> io::Result<()> {
     let tmp = dst.with_extension("partial.tmp");
     fs::write(&tmp, bytes)?;
     if let Err(e) = fs::rename(&tmp, dst) {
+        tracing::debug!(dst = %dst.display(), error = %e, "atomic rename failed; writing in place");
         fs::write(dst, bytes)?;
         let _ = fs::remove_file(&tmp);
-        return Err(e);
     }
     Ok(())
 }

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "controller-pack-installer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/installer/src-tauri/src/local_packages.rs
+++ b/installer/src-tauri/src/local_packages.rs
@@ -47,6 +47,19 @@ pub fn extract_package(path: &Path) -> anyhow::Result<LocalPackage> {
         other => anyhow::bail!("unsupported package type '.{other}' (expected .zip or .7z)"),
     }
 
+    // GNG archives are built on Windows and sometimes carry `\`-separated entry
+    // names. Those only split into directories when extracted *on* Windows, so
+    // off Windows the tree has to be rebuilt before the planner walks it.
+    let moved = controller_pack_core::archive_paths::normalize_windows_separators(tmp.path())
+        .with_context(|| format!("normalizing entry names of {}", path.display()))?;
+    if moved > 0 {
+        tracing::debug!(
+            archive = %path.display(),
+            moved,
+            "rebuilt Windows-style archive entry names"
+        );
+    }
+
     let root = tmp.path().to_path_buf();
     Ok(LocalPackage { _tmp: tmp, root })
 }

--- a/installer/src-tauri/src/profile_store/mod.rs
+++ b/installer/src-tauri/src/profile_store/mod.rs
@@ -1,12 +1,12 @@
 //! Persistence layer for the user profile. Data types live in
-//! `controller_pack_core::profile_types`; this module wraps them with
-//! `tauri-plugin-store` load/save and the controller-pack-detection helper.
+//! `controller_pack_core::profile_types` and the pack-detection helpers in
+//! `controller_pack_core::pack_dir`; this module wraps them with
+//! `tauri-plugin-store` load/save.
 
+pub use controller_pack_core::pack_dir::{detect_pack_dir, looks_like_controller_pack};
 pub use controller_pack_core::profile_types::{
     InstalledVersions, Preferences, Profile, VatsimCredentials,
 };
-use controller_pack_core::AreaCode;
-use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Runtime};
 use tauri_plugin_store::StoreExt;
 
@@ -28,47 +28,3 @@ pub fn save<R: Runtime>(app: &AppHandle<R>, profile: &Profile) -> anyhow::Result
     Ok(())
 }
 
-pub fn looks_like_controller_pack(path: &Path) -> bool {
-    let has_lfxx = path.join("LFXX").is_dir();
-    // Any area folder counts, LFFM included — it is not a FIR, but a pack that
-    // only installed the military area is still a controller pack.
-    let has_any_area = AreaCode::ALL
-        .iter()
-        .any(|area| path.join(area.as_str()).is_dir());
-    has_lfxx && has_any_area
-}
-
-pub fn detect_pack_dir() -> Option<PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    if looks_like_controller_pack(&cwd) {
-        Some(cwd)
-    } else {
-        None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    #[test]
-    fn looks_like_controller_pack_requires_lfxx_and_one_area() {
-        let tmp = tempdir().unwrap();
-        let root = tmp.path();
-        assert!(!looks_like_controller_pack(root));
-        std::fs::create_dir_all(root.join("LFXX")).unwrap();
-        assert!(!looks_like_controller_pack(root));
-        std::fs::create_dir_all(root.join("LFBB")).unwrap();
-        assert!(looks_like_controller_pack(root));
-    }
-
-    #[test]
-    fn lffm_only_pack_is_recognised() {
-        let tmp = tempdir().unwrap();
-        let root = tmp.path();
-        std::fs::create_dir_all(root.join("LFXX")).unwrap();
-        std::fs::create_dir_all(root.join("LFFM")).unwrap();
-        assert!(looks_like_controller_pack(root));
-    }
-}

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -26,11 +26,20 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": ["nsis", "app", "dmg"],
     "createUpdaterArtifacts": true,
+    "category": "Utility",
+    "shortDescription": "Installs and updates the French vACC controller pack",
     "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "minimumSystemVersion": "10.15"
+    }
   },
   "plugins": {
     "updater": {

--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "French vACC Controller Pack Installer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "fr.vacc.controller-pack-installer",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## What

The installer now builds, runs and releases on macOS as well as Windows. EuroScope itself is Windows-only, but plenty of controllers run it under Wine/CrossOver/Whisky — and the installer is just a folder merger that patches text files, so there was nothing platform-bound about it.

## Bundle config

- `targets` gains `app` + `dmg`. Tauri intersects that list with what the host platform supports, so **a Windows build still produces the NSIS installer alone** — confirmed with a local `tauri build`: *"Finished 1 bundle"*.
- The icon list now references the `.icns` and the PNG sizes (all already in `icons/`); `tauri-build` still picks `icon.ico` for the exe resource, and NSIS never read that list to begin with.
- `macOS.minimumSystemVersion` plus a bundle category.

## Two things genuinely assumed Windows

- **Pack detection** only looked at `current_dir()`, which is never the pack folder for a normally installed app. It now scans `~/Documents`, `~/Desktop`, `~`, and the `Documents` folder of every Windows user inside every Wine/CrossOver/Whisky bottle it can find. (`core/src/pack_dir.rs`)
- **`\`-separated archive entries.** Some GNG archives store entry names with backslashes. Those split into real folders only when extracted *on* Windows; anywhere else the package lands as files literally named `LFBB\ICAO\LFBB.txt`, the planner finds no FIR folders, and the install silently does nothing. Extraction now rebuilds those paths, refusing traversal names rather than guessing at them. (`core/src/archive_paths.rs`)

## Drive-by fix

`apply()`'s atomic-write fallback copied the file successfully and then returned the error anyway, aborting the whole sync whenever a rename was refused. If the copy itself fails it still errors out, exactly as before.

## Release pipeline

New `release-build-macos` job: universal (Apple Silicon + Intel) `.app` + `.dmg`, signed with the existing Tauri updater key. It runs **after** the Windows job rather than alongside it — `tauri-action` merges each platform into the release's single `latest.json`, so concurrent jobs would drop one of them.

Apple code signing / notarization is **optional**: with no secrets configured the app builds unsigned and still auto-updates, users just need the Gatekeeper right-click → Open once. `RELEASE.md` documents both paths, the secrets required, and the updated asset checklist (`latest.json` should list `windows-x86_64`, `darwin-aarch64`, `darwin-x86_64`).

## Testing

- `cargo test -p controller-pack-core` — 47 pass on Windows, 52 on Linux (the 5 extra are the new non-Windows path tests).
- Local `bun run tauri build` on Windows — NSIS installer produced as before. Only the updater-signing step fails locally, for lack of `TAURI_SIGNING_PRIVATE_KEY`; CI supplies it.

## Heads-up

The smoke build is now a Linux + macOS matrix, so its check name changed from `Linux smoke build` to `Smoke build (ubuntu-latest)` / `Smoke build (macos-latest)`. If `main`'s branch protection requires the old name, it needs updating.

The version bump to 0.1.3 is a separate commit — drop it if it doesn't fit the release plan.
